### PR TITLE
Enhance build system compiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 *.exe
 *.out
 *.app
+
+# Output of CMake configure files
+include/common.hxx

--- a/CMake/set_compiler_flags.cmake
+++ b/CMake/set_compiler_flags.cmake
@@ -4,6 +4,10 @@
 
 # ============================================================================
 #
+# 2025-11-03 Ljubomir Kurij <ljubomir_kurij@proton.me>
+#
+# * Updated Intel compiler flags to include optimization report generation
+#
 # 2025-09-21 Ljubomir Kurij <ljubomir_kurij@proton.me>
 #
 # * Created.
@@ -16,13 +20,11 @@
 function (set_compiler_flags)
   # Check which compiler is being used and set flags accordingly
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message (STATUS "Using Clang compiler ...")
     # -------------------------------------------------------------------------
     # Clang-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      # "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -Werror"
-      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -lstdc++"
+      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic"
       )
     set (RELEASE_FLAGS
       "-O3 -DNDEBUG -march=native -fvectorize -flto"
@@ -38,13 +40,11 @@ function (set_compiler_flags)
       )
       
   elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    message (STATUS "Using GNU compiler ...")
     # -------------------------------------------------------------------------
     # GNU-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      # "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -Werror"
-      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -Werror"
+      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic"
       )
     set (RELEASE_FLAGS
       "-O3 -DNDEBUG -march=native -ftree-vectorize -flto"
@@ -60,12 +60,10 @@ function (set_compiler_flags)
       )
       
   elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    message (STATUS "Using MSVC compiler ...")
     # -------------------------------------------------------------------------
     # MSVC-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      # "/Zi /Od /Ob0 /MDd /W4 /WX /permissive- /RTC1"
       "/Zi /Od /Ob0 /MDd /W4 /permissive- /RTC1"
       )
     set (RELEASE_FLAGS
@@ -84,24 +82,46 @@ function (set_compiler_flags)
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel"
     OR CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM"
     )
-    message (STATUS "Using Intel compiler ...")
     # -------------------------------------------------------------------------
     # Intel-specific flags
     # -------------------------------------------------------------------------
+
+    # Debugging info, no optimization, all warnings
     set(DEBUG_FLAGS
-      # "-g3 -O0 -Wall -Wextra -Werror -traceback"
-      "-g3 -O0 -Wall -Wextra -traceback"
+      "-g3 -O0 -Wall -Wextra"
       )
+
+    # Optimize for maximum speed, enable interprocedural optimization,
+    # generate optimization report
     set(RELEASE_FLAGS
-      "-O3 -DNDEBUG -xHost -ipo"
+      "-O3 -DNDEBUG -xHost -ipo -qopt-report=3"
       )
+    string(APPEND
+      RELEASE_FLAGS
+      " -qopt-report-file=optimization_report.yaml"
+      )
+
+    # Optimize for size, enable interprocedural optimization,
+    # generate optimization report
     set(MINSIZEREL_FLAGS
-      "-Os -DNDEBUG -ipo"
+      "-Os -DNDEBUG -ipo -qopt-report=3"
       )
-    set(RELWITHDEBINFO_FLAGS
-      "-O2 -g -DNDEBUG -xHost -ipo")
+    string(APPEND
+      MINSIZEREL_FLAGS
+      " -qopt-report-file=optimization_report.yaml"
+      )
     set(MINSIZEREL_LINKER_FLAGS
       "-Wl,--gc-sections -Wl,--strip-all"
+      )
+
+    # Moderate optimization with debugging info, enable interprocedural
+    # optimization, generate optimization report
+    set(RELWITHDEBINFO_FLAGS
+      "-O2 -g -DNDEBUG -xHost -ipo -qopt-report=3"
+      )
+    string(APPEND
+      RELWITHDEBINFO_FLAGS
+      " -qopt-report-file=optimization_report.yaml"
       )
   endif()
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 # ============================================================================
 #
+# 2025-11-03 Ljubomir Kurij <ljubomir_kurij@proton.me>
+#
+# * Added output messages for compiler options based on build type.
+#
 # 2025-09-21 Ljubomir Kurij <ljubomir_kurij@proton.me>
 #
 # * Created.
@@ -93,15 +97,41 @@ else ()
   set(USE_DEBUG OFF)
 endif ()
 
-# Set custom compiler options
-message (STATUS "Setting custom compiler options ...")
+# Set C++ compiler options
+message (STATUS "Setting C++ compiler options ...")
 include ("${CMAKE_SOURCE_DIR}/CMake/set_compiler_flags.cmake")
 set_compiler_flags()
-message (STATUS "Custom compiler options set to: `"
-  ${CMAKE_CXX_FLAGS} " "
-  ${CMAKE_CXX_FLAGS_DEBUG}
-  "' ..."
-  )
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message (STATUS "C++ compiler options set to: `"
+    ${CMAKE_CXX_FLAGS} " "
+    ${CMAKE_CXX_FLAGS_DEBUG}
+    "' ..."
+    )
+elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+  message (STATUS "C++ compiler options set to: `"
+    ${CMAKE_CXX_FLAGS} " "
+    ${CMAKE_CXX_FLAGS_RELEASE}
+    "' ..."
+    )
+elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+  message (STATUS "C++ compiler options set to: `"
+    ${CMAKE_CXX_FLAGS} " "
+    ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}
+    "' ..."
+    )
+elseif (CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+  message (STATUS "C++ compiler options set to: `"
+    ${CMAKE_CXX_FLAGS} " "
+    ${CMAKE_CXX_FLAGS_MINSIZEREL}
+    "' ..."
+    )
+else()
+  message(ERROR "Unknown CMAKE_BUILD_TYPE: `"
+    ${CMAKE_BUILD_TYPE}
+    "' ..."
+    )
+endif()
+
 
 # -----------------------------------------------------------------------------
 # Check if we are building with the unit tests

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ repositories but are still valuable and interesting to keep.
   - [Introduction](#introduction)
   - [Compile Targets](#compile-targets)
   - [Getting Started](#getting-started)
+  - [Known Issues](#known-issues)
   - [License](#license)
 
 ## Introduction
@@ -61,6 +62,25 @@ code examples that inerest you.
 
 5. **Experiment and Learn:** Tinker with the code, modify parameters, and see
 the effects. Learn by experimentation and observation.
+
+## Known Issues
+
+If compiling with Intel's oneAPI compiler, set -DBUILD_TESTS to OFF, for
+Release, MinSizeRel, and RelWithDebInfo. Otherwise linking fails with the
+message:
+
+```shell
+/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/crt1.o: in function `_start':
+(.text+0x1b): undefined reference to `main'
+/usr/bin/ld: /usr/bin/ld: DWARF error: could not find variable specification at offset 429d
+/tmp/lto-llvm-d920f3.o: in function `_GLOBAL__sub_I_dummy_test.cxx':
+
+...
+
+icpx: error: linker command failed with exit code 1 (use -v to see invocation)
+
+...
+```
 
 ## License
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -6,6 +6,10 @@
 #
 # 2025-09-21 Ljubomir Kurij <ljubomir_kurij@proton.me>
 #
+# * Google Test package updated to v1.17.0.
+#
+# 2025-09-21 Ljubomir Kurij <ljubomir_kurij@proton.me>
+#
 # * Created.
 #
 # ============================================================================
@@ -44,7 +48,7 @@ if (BUILD_TESTS)
 	FetchContent_Declare(
 	  googletest
 		GIT_REPOSITORY https://github.com/google/googletest
-		GIT_TAG        52eb8108c5bdec04579160ae17225d66034bd723
+		GIT_TAG        v1.17.0
 	)
 
 	add_subdirectory(GoogleTest)

--- a/extern/GoogleTest/CMakeLists.txt
+++ b/extern/GoogleTest/CMakeLists.txt
@@ -4,14 +4,64 @@
 
 # ============================================================================
 #
+# 2025-11-03 Ljubomir Kurij <ljubomir_kurij@proton.me>
+#
+# * Patches for IntelLLVM compiler support.
+#
 # 2025-09-21 Ljubomir Kurij <ljubomir_kurij@proton.me>
 #
 # * Created.
 #
 # ============================================================================
 
-# Make sure that `GoogleTest' is available
-FetchContent_MakeAvailable(googletest)
+if (CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM")
+  # Apply patches to `GoogleTest' when using IntelLLVM compiler
+  message(STATUS
+    "Using IntelLLVM compiler - applying patches to `GoogleTest' ..."
+    )
+  FetchContent_GetProperties(googletest)
+
+  if(NOT googletest_POPULATED)
+    FetchContent_Populate(googletest)
+    
+    message(STATUS "Patching `GoogleTest' for IntelLLVM compiler ...")
+    file(READ
+      "${googletest_SOURCE_DIR}/googletest/cmake/internal_utils.cmake"
+      FILE_CONTENTS
+      )
+    # As of v2025.20, correct switch for the IntelLLVM compiler is
+    # `-Wno-sycl-implicit-float-size-conversion' instead of
+    # `-Wno-implicit-float-size-conversion'
+    message(STATUS
+      "Replacing deprecated flag "
+      "`-Wno-implicit-float-size-conversion' ..."
+      )
+    string(REPLACE
+      "-Wno-implicit-float-size-conversion"
+      "-Wno-sycl-implicit-float-size-conversion"
+      FILE_CONTENTS "${FILE_CONTENTS}"
+      )
+    # Remove `-Winline' flag which is not supported by IntelLLVM compiler
+    message(STATUS
+      "Removing unsupported flag `-Winline' ..."
+      )
+    string(REPLACE
+      "-Winline "
+      ""
+      FILE_CONTENTS "${FILE_CONTENTS}"
+      )
+    file(WRITE
+      "${googletest_SOURCE_DIR}/googletest/cmake/internal_utils.cmake"
+      "${FILE_CONTENTS}"
+      )
+      message(STATUS "Patching completed.")
+    
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+  endif()
+else ()
+  # Make sure that `GoogleTest' is available if not using IntelLLVM compiler
+  FetchContent_MakeAvailable(googletest)
+endif()
 
 
 # End of `CMakeLists.txt'


### PR DESCRIPTION
* Changes:
  - Updated Intel compiler flags to enable optimization report generation
  - Added output message reflecting compiler options per build type
  - Upgraded Google Test to v1.17.0
  - Applied patches for IntelLLVM compiler compatibility

* Affected directories and files:
  - .gitignore
  - CMake/set_compiler_flags.cmake
  - CMakeLists.txt
  - README.md
  - extern/CMakeLists.txt
  - extern/GoogleTest/CMakeLists.txt