### PR TITLE
Ljubomir/compile fix/compile against correct cpp runtime

### DIFF
--- a/CMake/set_compiler_flags.cmake
+++ b/CMake/set_compiler_flags.cmake
@@ -24,16 +24,16 @@ function (set_compiler_flags)
     # Clang-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic"
+      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -lstdc++"
       )
     set (RELEASE_FLAGS
-      "-O3 -DNDEBUG -march=native -fvectorize -flto"
+      "-O3 -DNDEBUG -march=native -fvectorize -flto -lstdc++"
       )
     set (MINSIZEREL_FLAGS
-      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto"
+      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto -lstdc++"
       )
     set (RELWITHDEBINFO_FLAGS
-      "-O2 -g -DNDEBUG -march=native -fvectorize"
+      "-O2 -g -DNDEBUG -march=native -fvectorize -lstdc++"
       )
     set (MINSIZEREL_LINKER_FLAGS
       "-Wl,--gc-sections -Wl,--strip-all"
@@ -44,16 +44,17 @@ function (set_compiler_flags)
     # GNU-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic"
+      # "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -Werror"
+      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -lstdc++"
       )
     set (RELEASE_FLAGS
-      "-O3 -DNDEBUG -march=native -ftree-vectorize -flto"
+      "-O3 -DNDEBUG -march=native -ftree-vectorize -flto -lstdc++"
       )
     set (MINSIZEREL_FLAGS
-      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto"
+      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto -lstdc++"
       )
     set (RELWITHDEBINFO_FLAGS
-      "-O2 -g -DNDEBUG -march=native -ftree-vectorize"
+      "-O2 -g -DNDEBUG -march=native -ftree-vectorize -lstdc++"
       )
     set (MINSIZEREL_LINKER_FLAGS
       "-Wl,--gc-sections -Wl,--strip-all"

--- a/CMake/set_compiler_flags.cmake
+++ b/CMake/set_compiler_flags.cmake
@@ -24,16 +24,16 @@ function (set_compiler_flags)
     # Clang-specific flags
     # -------------------------------------------------------------------------
     set (DEBUG_FLAGS
-      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic -lstdc++"
+      "-g3 -O0 -fno-omit-frame-pointer -Wall -Wextra -Wpedantic"
       )
     set (RELEASE_FLAGS
-      "-O3 -DNDEBUG -march=native -fvectorize -flto -lstdc++"
+      "-O3 -DNDEBUG -march=native -fvectorize -flto"
       )
     set (MINSIZEREL_FLAGS
-      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto -lstdc++"
+      "-Os -DNDEBUG -ffunction-sections -fdata-sections -flto"
       )
     set (RELWITHDEBINFO_FLAGS
-      "-O2 -g -DNDEBUG -march=native -fvectorize -lstdc++"
+      "-O2 -g -DNDEBUG -march=native -fvectorize"
       )
     set (MINSIZEREL_LINKER_FLAGS
       "-Wl,--gc-sections -Wl,--strip-all"

--- a/src/resource_release_study.cxx
+++ b/src/resource_release_study.cxx
@@ -15,7 +15,6 @@ int main(int argc, char* argv[]) {
 
     using namespace LoggingService;
 
-	using String = std::string;
 	using DataSet = std::vector<DummyClass::DummyClass>;
 	using DataStack = std::vector<DataSet>;
 


### PR DESCRIPTION
fix(CMake):
- Enable compilation against the correct C++ runtime for the GNU C++ compiler.
- Remove unused local typdefs.